### PR TITLE
fix package.json to point to greenstand repo, not phil's fork

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,15 +14,15 @@ jobs:
     - name: Sync files
       uses: SamKirkland/FTP-Deploy-Action@4.3.0
       with:
-        server: 156.67.236.37
-        username: p366052f3
+        server: philnorcross.com
+        username: green
         protocol: ftp
         security: loose
         local-dir: greenorg/docs/ttxt/
         server-dir: /ttxt/
-        dry-run: true
+        dry-run: false
         log-level: verbose
-        password: ${{ secrets.FTP_PASSWORD }}
+        password: ${{ secrets.philftp }}
         state-name: .deployHistory
         port: 21
         

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .git
 .github
 */main.yaml
+.github/workflows/main.yaml
 a.*
 logs.d/*
 kill

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ],
     "watch": [
       "*.js",
-      "pnconfig.json"
+      "config.json"
     ],
     "ignore": [
       "a.*",
@@ -41,9 +41,9 @@
   "engines": {"node": ">=8.11.1"},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/philnorc/greenstand-documentation.git"
+    "url": "git+https://github.com/Greenstand/greenstand-documentation.git"
   },
   "keywords": ["Greenstand","documentation"],
-  "bugs": {"url": "https://github.com/philnorc/greenstand-documentation/issues"},
-  "homepage": "https://github.com/philnorc/greenstand-documentation#readme"
+  "bugs": {"url": "https://github.com/Greenstand/greenstand-documentation/issues"},
+  "homepage": "https://github.com/Greenstand/greenstand-documentation#readme"
 }


### PR DESCRIPTION
The workflow/main.yaml should be ignored, not synced.