### PR TITLE
fix failure to ignore at sync

### DIFF
--- a/.github/workflows/forkdeployer.yaml
+++ b/.github/workflows/forkdeployer.yaml
@@ -22,7 +22,7 @@ jobs:
         server-dir: /ttxt/
         dry-run: false
         log-level: verbose
-        password: ${{ secrets.philftp }}
+        password: ${{ secrets.PHILFTP }}
         state-name: .deployHistory
         port: 21
         

--- a/.github/workflows/forkdeployer.yaml
+++ b/.github/workflows/forkdeployer.yaml
@@ -1,0 +1,29 @@
+on:
+  workflow_dispatch:
+permissions: read-all
+env:
+  project-directory: ./
+name: Deploy website
+jobs:
+  web-deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest code
+      uses: actions/checkout@v2    
+    - name: Sync files
+      uses: SamKirkland/FTP-Deploy-Action@4.3.0
+      with:
+        server: philnorcross.com
+        username: green
+        protocol: ftp
+        security: loose
+        local-dir: greenorg/docs/ttxt/
+        server-dir: /ttxt/
+        dry-run: false
+        log-level: verbose
+        password: ${{ secrets.philftp }}
+        state-name: .deployHistory
+        port: 21
+        
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 .git
-.github
-*/main.yaml
-.github/workflows/main.yaml
 a.*
 logs.d/*
 kill


### PR DESCRIPTION
Because syncing this repo and the fork at philnorc failed to ignore the deplyment script, there are now two deploy scripts: main is for the Greenstand repo, forkdeployer is for the fork at philnorc.