### PR TITLE
Add treetracker ios testing instructions

### DIFF
--- a/treetracker/development/treetracker-ios-testing-instructions.md
+++ b/treetracker/development/treetracker-ios-testing-instructions.md
@@ -1,0 +1,20 @@
+# TreeTracker iOS Testing Instructions
+
+1. Request an email 'invitation' from iOS Team to the testing environment
+2. Download the TestFlight app on an iPhone
+3. Press the 'Redeem' button on the top right corner and enter the invitation code from the email
+4. Download the corresponding build on the phone
+5. Sign up and login to the Treetracker testing app
+6. Check ability to change users
+7. Use app to capture image and record (Note: The app has a block for GPS accuracy. The user should be able to get GPS reception, "add a tree." Take a photo and upload the image.)
+    * time per capture
+    * any bugs
+    * any unclear UX/UI
+8. Sync data
+9. Confirm data reaches the cloud by:
+    * checking that the images should appear on the map at test.treetracker.org
+    * logging into the Tree Tracker Admin URL, https://test-admin.treetracker.org/
+        * username: admin
+        * password: ZwovDoOxCo
+10. You can submit any defects/suggestions here under the Issues tab. https://github.com/Greenstand/treetracker-ios
+11. If all checks ok, please report to the iOS Team

--- a/treetracker/development/treetracker-ios-testing-instructions.md
+++ b/treetracker/development/treetracker-ios-testing-instructions.md
@@ -13,8 +13,6 @@
 8. Sync data
 9. Confirm data reaches the cloud by:
     * checking that the images should appear on the map at test.treetracker.org
-    * logging into the Tree Tracker Admin URL, https://test-admin.treetracker.org/
-        * username: admin
-        * password: ZwovDoOxCo
+    * logging into the Tree Tracker Admin URL, https://test-admin.treetracker.org/ (login information is available in the Slack channel)
 10. You can submit any defects/suggestions here under the Issues tab. https://github.com/Greenstand/treetracker-ios
 11. If all checks ok, please report to the iOS Team


### PR DESCRIPTION
I added the treetracker ios testing instruction document to the treetracker development folder. This should resolve [issue 43](https://github.com/Greenstand/greenstand-documentation/issues/43).