### PR TITLE
Updated Link to Policies

### DIFF
--- a/docs/organizational-policies/index-of-policies.md
+++ b/docs/organizational-policies/index-of-policies.md
@@ -4,24 +4,27 @@
 
 If you don’t find what you are looking for, please ask someone at Greenstand. IF the policy doesn’t exist and you think we need it, please make a request to produce such a policy.
 
-#### [Safeguard and Whistleblower Protection Policy](https://drive.google.com/file/d/1JJ8G3NoBYIP7Rzi4JyrPr64XrN1LsLt1/view?usp=sharing) <a href="#docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110" id="docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110"></a>
-
-#### [Environmental Policy](https://drive.google.com/file/d/1f24iuOBIvp97haYOGK7fQDB2yB2u3xy3/view?usp=sharing)
-
-#### [Financial Control policy, Internal and External Controls](https://drive.google.com/file/d/1IKIyW5GosYPrhI0xeiRwAVJZNTLHmFVu/view?usp=sharing)
-
-#### [Data Protection Policy](https://drive.google.com/file/d/1Bv32GOFaWEUVRfBkGLi8-5a7hRqpnguj/view?usp=sharing)&#x20;
-
-#### [Privacy Policy](https://drive.google.com/file/d/17-NcPYuvFnx9UlDMY2FF3NxV5\_hOudQL/view?usp=sharing)
-
 #### [Conflict of Interest Policy](https://drive.google.com/file/d/18r8IX\_6JaniXqef8\_RUM-Lo2CKDoJzhB/view?usp=sharing)
 
 #### [Code of Conduct](https://drive.google.com/file/d/1y8l17FWt7uCeOSRhkOoznU8iOPquvxtK/view?usp=sharing)
 
+#### [Data Protection Policy](https://drive.google.com/file/d/1Bv32GOFaWEUVRfBkGLi8-5a7hRqpnguj/view?usp=sharing)&#x20;
+
+#### [Safeguard and Whistleblower Protection Policy](https://drive.google.com/file/d/1JJ8G3NoBYIP7Rzi4JyrPr64XrN1LsLt1/view?usp=sharing) <a href="#docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110" id="docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110"></a>
+
+#### [Environmental Policy](https://drive.google.com/file/d/1f24iuOBIvp97haYOGK7fQDB2yB2u3xy3/view?usp=sharing)
+
+#### [Financial policy, Internal and External Controls](https://drive.google.com/file/d/1IKIyW5GosYPrhI0xeiRwAVJZNTLHmFVu/view?usp=sharing)
+
+#### [Privacy Policy](https://drive.google.com/file/d/17-NcPYuvFnx9UlDMY2FF3NxV5\_hOudQL/view?usp=sharing)
+
 #### [External Communications Policy](https://drive.google.com/file/d/1Mdr8K\_JDAsf8gUAHkotoICGQqgP7WBo4/view?usp=sharing)
 
-#### [Greenstand Bylaws](https://drive.google.com/file/d/1gH82qoED5mg8rMkzVJEAqauUCfAEfL8J/view?usp=sharing)
+#### [Bylaws](https://drive.google.com/file/d/1gH82qoED5mg8rMkzVJEAqauUCfAEfL8J/view?usp=sharing)
 
-#### Procurement and Policy and Procedures <a href="#docs-internal-guid-115d5ccb-7fff-4a33-a776-f3d3940ad044" id="docs-internal-guid-115d5ccb-7fff-4a33-a776-f3d3940ad044"></a>
+#### [Recommendation and Verification Letter Policy](https://drive.google.com/file/d/1VswhS3OctlDxZB58mkFErLawN_ZS0V89/view?usp=sharing)
 
+#### [Hiring and Employment Policy](https://drive.google.com/file/d/12V9FD4JUMarJRtQgodm1PumpnJRMGu5p/view?usp=sharing)
+
+#### [Non-Discrimination Policy](https://drive.google.com/file/d/1T9ZSzmWnRrzVYeXyOJ04GciXdPI6udNK/view?usp=sharing)
 &#x20;

--- a/docs/organizational-policies/index-of-policies.md
+++ b/docs/organizational-policies/index-of-policies.md
@@ -1,30 +1,3 @@
-# Index of Policies
-
-### Greenstand embraces continuous improvement
-
-If you don’t find what you are looking for, please ask someone at Greenstand. IF the policy doesn’t exist and you think we need it, please make a request to produce such a policy.
-
-#### [Conflict of Interest Policy](https://drive.google.com/file/d/18r8IX\_6JaniXqef8\_RUM-Lo2CKDoJzhB/view?usp=sharing)
-
-#### [Code of Conduct](https://drive.google.com/file/d/1y8l17FWt7uCeOSRhkOoznU8iOPquvxtK/view?usp=sharing)
-
-#### [Data Protection Policy](https://drive.google.com/file/d/1Bv32GOFaWEUVRfBkGLi8-5a7hRqpnguj/view?usp=sharing)&#x20;
-
-#### [Safeguard and Whistleblower Protection Policy](https://drive.google.com/file/d/1JJ8G3NoBYIP7Rzi4JyrPr64XrN1LsLt1/view?usp=sharing) <a href="#docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110" id="docs-internal-guid-6c6d04ad-7fff-5b59-1f27-4a190f4f6110"></a>
-
-#### [Environmental Policy](https://drive.google.com/file/d/1f24iuOBIvp97haYOGK7fQDB2yB2u3xy3/view?usp=sharing)
-
-#### [Financial policy, Internal and External Controls](https://drive.google.com/file/d/1IKIyW5GosYPrhI0xeiRwAVJZNTLHmFVu/view?usp=sharing)
-
-#### [Privacy Policy](https://drive.google.com/file/d/17-NcPYuvFnx9UlDMY2FF3NxV5\_hOudQL/view?usp=sharing)
-
-#### [External Communications Policy](https://drive.google.com/file/d/1Mdr8K\_JDAsf8gUAHkotoICGQqgP7WBo4/view?usp=sharing)
-
-#### [Bylaws](https://drive.google.com/file/d/1gH82qoED5mg8rMkzVJEAqauUCfAEfL8J/view?usp=sharing)
-
-#### [Recommendation and Verification Letter Policy](https://drive.google.com/file/d/1VswhS3OctlDxZB58mkFErLawN_ZS0V89/view?usp=sharing)
-
-#### [Hiring and Employment Policy](https://drive.google.com/file/d/12V9FD4JUMarJRtQgodm1PumpnJRMGu5p/view?usp=sharing)
-
-#### [Non-Discrimination Policy](https://drive.google.com/file/d/1T9ZSzmWnRrzVYeXyOJ04GciXdPI6udNK/view?usp=sharing)
+# Index of active policies 
+[Index and Link to policies can be found here](https://docs.google.com/document/d/1yfPh7CzkoImd-v14XLATzVKz_kKHk2DaPNCU-8PK2Cs/edit?usp=sharing)
 &#x20;

--- a/wallet-admin/development/README.md
+++ b/wallet-admin/development/README.md
@@ -16,6 +16,15 @@ A green marketing company is utilizing the Treetracker platform to plant/maintai
 
 Company A is selling hand made leather boots and communicates to their clients that with every pair of boots sold the company is going to pay planters to grow trees. To manage the creation of wallets and adding tokens into the end consumer clients wallet the Treetracker Wallet Admin Client is used to interact with the Wallet API.
 
+#### [Wallet Logic Documention](https://docs.google.com/document/d/1u4PSFrO_SCGPq2HI1fl_JfrRaOxMn4pFyjbT50C5Bt4/edit)
+#### [Wallet User guides](https://greenstand.org/docs/user-guides/walletapihow.php)
+
+#### [User Stories](https://docs.google.com/document/d/1IF4fe4_BC319aoBKBW5LV2pypyDTy4K8qe1qqHexQ1Y/edit?usp=sharing)
+
 ### Github
 
+[Project Wallet Admin Client](https://github.com/orgs/Greenstand/projects/75/views/1)
+
 Link: [https://github.com/Greenstand/treetracker-wallet-admin-client](https://github.com/Greenstand/treetracker-wallet-admin-client)
+
+#### [Edit this documentation here via fork and pull](https://github.com/Greenstand/greenstand-documentation/blob/97c41ab1723842b704f5f73b63a13fdb88b92802/wallet-admin/development/README.md?plain=1#L2)


### PR DESCRIPTION
I updated the link to the Polices, by placing a single link to the index that we retain on Google Drive. 

This seems like the easiest way to bridge the gap between operations and tech with documentation.  